### PR TITLE
fix: docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,32 @@
-services:
-  frontend:
-    container_name: frontend
-    build:
-      context: ./frontend
-      dockerfile: prod.Dockerfile
-      args:
-        ENV_VARIABLE: ${ENV_VARIABLE}
-        NEXT_PUBLIC_ENV_VARIABLE: ${NEXT_PUBLIC_ENV_VARIABLE}
-    restart: always
-    ports:
-      - 3000:3000
+# services:
+#   frontend:
+#     container_name: frontend
+#     build:
+#       context: ./frontend
+#       dockerfile: prod.Dockerfile
+#       args:
+#         ENV_VARIABLE: ${ENV_VARIABLE}
+#         NEXT_PUBLIC_ENV_VARIABLE: ${NEXT_PUBLIC_ENV_VARIABLE}
+#     restart: always
+#     ports:
+#       - 3000:3000
     
-  nginx:
-    container_name: nginx
-    image: nginx:latest
-    restart: always
-    volumes:
-      - ./conf/nginx.conf:/etc/nginx/conf.d/nginx.conf
-    ports:
-      - 80:80
-      - 443:443
-    depends_on:
-      - frontend
+#   nginx:
+#     container_name: nginx
+#     image: nginx:latest
+#     restart: always
+#     volumes:
+#       - ./conf/nginx.conf:/etc/nginx/conf.d/nginx.conf
+#     ports:
+#       - 80:80
+#       - 443:443
+#     depends_on:
+#       - frontend
 
-  # Add more containers below (nginx, postgres, etc.)
+#   # Add more containers below (nginx, postgres, etc.)
 
-# Define a network, which allows containers to communicate
-# with each other, by using their container name as a hostname
-networks:
-  my_network:
-    external: true
+# # Define a network, which allows containers to communicate
+# # with each other, by using their container name as a hostname
+# networks:
+#   my_network:
+#     external: true

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,9 +1,12 @@
-version: "3"
+# version: "3"
 services:
   frontend:
     build:
       context: .
       dockerfile: ./docker/next.Dockerfile
+    # platform for ec2 environment
+    platform: linux/x86_64
+    image: yyoooonn/aimlfront:latest
     ports:
       - 3000:3000
 
@@ -11,6 +14,9 @@ services:
     build:
       context: .
       dockerfile: ./docker/nginx/nginx.Dockerfile
+    # platform for ec2 environment
+    platform: linux/x86_64
+    image: yyoooonn/aimlfrontnginx:latest
     ports:
       - 80:80
     depends_on:


### PR DESCRIPTION
docker image build 과정에서 ec2 프리티어 사양으로는 너무 오래걸리고 멈추기도 함
-> docker hub 에 업로드하고 pull 받아서 사용하는 과정으로 변경

사용하지 않는 docker-compose.yml 파일 주석 처리
-> 추후 CI/CD 구현시 사용 예정